### PR TITLE
📝 Docs: Add JSDoc to Star Wars intro components

### DIFF
--- a/PROJETOS/20260121-remotion-claude-video-skill/src/StarWars.tsx
+++ b/PROJETOS/20260121-remotion-claude-video-skill/src/StarWars.tsx
@@ -5,6 +5,17 @@ import { IntroText } from "./components/IntroText";
 import { Logo } from "./components/Logo";
 import { Crawl } from "./components/Crawl";
 
+/**
+ * Main composition for the Star Wars intro parody.
+ *
+ * Orchestrates the sequence of events using Remotion's `Sequence` component:
+ * 1. `Starfield`: Background active throughout the entire video.
+ * 2. `IntroText`: "A long time ago..." style text (frames 0-150).
+ * 3. `Logo`: Zooming "EVIDÊNCIAS" logo (frames 150-300).
+ * 4. `Crawl`: Scrolling lyrics text (starts at frame 300).
+ *
+ * The background color is explicitly set to black using `AbsoluteFill`.
+ */
 export const StarWars: React.FC = () => {
   const { durationInFrames } = useVideoConfig();
 

--- a/PROJETOS/20260121-remotion-claude-video-skill/src/components/Crawl.tsx
+++ b/PROJETOS/20260121-remotion-claude-video-skill/src/components/Crawl.tsx
@@ -2,6 +2,19 @@ import React from "react";
 import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
 import { lyrics } from "../lyrics";
 
+/**
+ * Renders the iconic scrolling text crawl.
+ *
+ * This component displays the lyrics of "Evidências" (Chitãozinho & Xororó)
+ * scrolling into the distance using a 3D perspective transform.
+ *
+ * Implementation details:
+ * - Uses `perspective: 400px` and `rotateX(25deg)` to create the vanishing point effect.
+ * - Interpolates `translateY` to move the text upwards from below the screen into the distance.
+ * - Includes a top gradient overlay to fade out the text as it gets "too far".
+ *
+ * The lyrics are sourced from `lyrics.ts`.
+ */
 export const Crawl: React.FC = () => {
   const frame = useCurrentFrame();
   const { height, width } = useVideoConfig();

--- a/PROJETOS/20260121-remotion-claude-video-skill/src/components/IntroText.tsx
+++ b/PROJETOS/20260121-remotion-claude-video-skill/src/components/IntroText.tsx
@@ -1,6 +1,17 @@
 import React from "react";
 import { AbsoluteFill, interpolate, useCurrentFrame } from "remotion";
 
+/**
+ * Displays the initial "A long time ago..." style text.
+ *
+ * This component fades in and out the text "Há muito tempo, em um karaokê muito, muito distante..."
+ * setting the humorous tone for the parody.
+ *
+ * The opacity is interpolated over frames:
+ * - 0-20: Fade in
+ * - 20-100: Hold
+ * - 100-120: Fade out
+ */
 export const IntroText: React.FC = () => {
   const frame = useCurrentFrame();
   const opacity = interpolate(frame, [0, 20, 100, 120], [0, 1, 1, 0], {

--- a/PROJETOS/20260121-remotion-claude-video-skill/src/components/Logo.tsx
+++ b/PROJETOS/20260121-remotion-claude-video-skill/src/components/Logo.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import { AbsoluteFill, interpolate, useCurrentFrame } from "remotion";
 
+/**
+ * Displays the main title logo "EVIDÊNCIAS" with a zoom-out effect.
+ *
+ * Simulates the iconic Star Wars logo receding into the distance.
+ *
+ * Effects:
+ * - Scale: Zooms out from 2x to 0x (disappearing into the distance).
+ * - Opacity: Fades in quickly, stays visible, then fades out as it disappears.
+ */
 export const Logo: React.FC = () => {
   const frame = useCurrentFrame();
 

--- a/PROJETOS/20260121-remotion-claude-video-skill/src/components/Starfield.tsx
+++ b/PROJETOS/20260121-remotion-claude-video-skill/src/components/Starfield.tsx
@@ -3,6 +3,15 @@ import { AbsoluteFill, useVideoConfig } from "remotion";
 
 const NUM_STARS = 200;
 
+/**
+ * Generates a static background of stars to simulate space.
+ *
+ * Uses `useMemo` to generate random star positions and properties (size, opacity)
+ * only once (or when video dimensions change), ensuring the stars remain
+ * static across frames and do not flicker or jump during playback.
+ *
+ * Generates {NUM_STARS} stars distributed randomly across the canvas.
+ */
 export const Starfield: React.FC = () => {
   const { width, height } = useVideoConfig();
   


### PR DESCRIPTION
Added comprehensive JSDoc to the Star Wars intro parody components in PROJETOS/20260121-remotion-claude-video-skill. Documented visual effects, interpolation logic, and implementation details for IntroText, Starfield, Logo, Crawl, and the main composition.

## Assumptions
- The project is a Remotion video template.
- The `mise.toml` configuration in the root is missing or not visible in this environment, so `mise run lint` was skipped, but `tsc` verified correctness.
- The lyrics in `lyrics.ts` are intentionally hardcoded.

## Alternatives Not Chosen
- Did not add unit tests for components as they are purely visual/declarative.
- Did not refactor the interpolation logic into hooks, kept it inline for clarity in documentation context.

## How To Pivot
- Revert the JSDoc blocks if they are deemed too verbose.
- Modify the documentation to be more concise if preferred.

## Next Knobs
- Add JSDoc to `lyrics.ts` if needed.
- Add JSDoc to `index.ts`.


---
*PR created automatically by Jules for task [10694686843888014690](https://jules.google.com/task/10694686843888014690) started by @lucasew*