### PR TITLE
🛟 Arrumador: Configure mise, workspaced, and CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,62 @@
+name: Auto Release
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: mise run install
+
+      - name: Run code generation
+        run: mise run codegen
+
+      - name: Create PR if codegen changed files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b auto-codegen-${GITHUB_SHA}
+            git add .
+            git commit -m "chore: auto update generated code"
+            git push origin auto-codegen-${GITHUB_SHA}
+            gh pr create --title "chore: auto update generated code" --body "Automated PR from codegen step." --head auto-codegen-${GITHUB_SHA}
+          else
+            echo "No changes detected."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run CI (Lint & Test)
+        run: mise run ci
+
+      - name: Create Release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          VERSION="v0.1.0-${GITHUB_SHA::7}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          gh release create "$VERSION" --title "Release $VERSION" --notes "Automated release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Artifacts
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          # If there are release artifacts to upload, do so here using gh release upload
+          echo "Placeholder for artifact upload"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,42 @@
+[tools]
+go = "1.22.5"
+node = "20.15.0"
+task = "3.38.0"
+"github:lucasew/workspaced" = "0.1.3"
+
+[tasks]
+lint = "workspaced codebase lint"
+fmt = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks.ci]
+depends = ["lint", "test"]
+
+[tasks."install:go"]
+run = "find . -name go.mod -execdir go mod tidy \\;"
+
+[tasks."install:npm"]
+run = "find . -name package.json -not -path '*/node_modules/*' -execdir npm install \\;"
+
+[tasks."install:rust"]
+run = "find . -name Cargo.toml -execdir cargo build \\;"
+
+[tasks."test:go"]
+run = "find . -name go.mod -execdir go test ./... \\;"
+
+[tasks."test:npm"]
+run = "find . -name package.json -not -path '*/node_modules/*' -execdir npm test --if-present \\;"
+
+[tasks."test:rust"]
+run = "find . -name Cargo.toml -execdir cargo test \\;"
+
+[tasks."codegen:make"]
+run = "find . -name Makefile -execdir make \\;"


### PR DESCRIPTION
## Assumptions
- The monorepo requires standard task aggregation using wildcard dependencies (`test:*`, `install:*`, `codegen:*`).
- Specific tools (`npm`, `go`, `cargo`, `make`) can be executed contextually within subdirectories containing matching files (`package.json`, `go.mod`, `Cargo.toml`, `Makefile`) via the `find ... -execdir ...` pattern.
- The project does not use Vercel or Cloudflare, meaning release and artifact generation conditionally runs on `dispatch` or `tag`.

## Alternatives Not Chosen
- Adding individual linter tools for Go, JS, or Rust manually. Decided against it per strict requirement to use `workspaced codebase lint`.
- Manually listing `install:go`, `test:npm`, etc., inside `depends`. Decided against it per strict requirement to use `wildcards`.

## How To Pivot
- If `find` causes unexpected behaviors on non-Unix systems, update the commands in `mise.toml` to a cross-platform alternative or define specific tasks explicitly for known subdirectories.

## Next Knobs
- `mise.toml` [tools]: Update tool pins.
- `mise.toml` [tasks.*]: Adjust `find` parameters or add/remove languages like Python or Ruby.
- `.github/workflows/autorelease.yml`: Add actual artifact paths inside the `Upload Artifacts` step.

---
*PR created automatically by Jules for task [5507031256308492343](https://jules.google.com/task/5507031256308492343) started by @lucasew*