### PR TITLE
📝 Docs: Add JSDoc to minicurso backend models

### DIFF
--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/Order.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/Order.js
@@ -1,5 +1,11 @@
 const mongoose = require("mongoose");
 
+/**
+ * Mongoose schema representing an active or completed order in the system.
+ * Orders link multiple products to the attendant handling them, and track the status of the order lifecycle.
+ *
+ * @type {mongoose.Schema}
+ */
 const OrderSchema = new mongoose.Schema({
   attendant: {
     type: mongoose.SchemaTypes.ObjectId,

--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/Product.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/Product.js
@@ -1,5 +1,11 @@
 const mongoose = require("mongoose");
 
+/**
+ * Mongoose schema representing a product available for order in the system.
+ * It tracks core product details like name, description, price, and categorizes them into snacks or drinks.
+ *
+ * @type {mongoose.Schema}
+ */
 const ProductSchema = new mongoose.Schema({
   name: {
     type: String,

--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/User.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/models/User.js
@@ -3,6 +3,13 @@ const jwt = require("jsonwebtoken");
 const authConfig = require("../config/auth");
 const mongoose = require("mongoose");
 
+/**
+ * Mongoose schema representing a registered user in the system.
+ * It is used for both administrators and regular attendants.
+ * Contains authentication data, timestamps, and an enum defining permission levels.
+ *
+ * @type {mongoose.Schema}
+ */
 const UserSchema = new mongoose.Schema({
   name: {
     type: String,
@@ -29,6 +36,12 @@ const UserSchema = new mongoose.Schema({
   }
 });
 
+/**
+ * Pre-save hook to intercept document saving and apply a cryptographic hash to the user's password.
+ * Only triggers if the password field is new or explicitly modified, preventing re-hashing of existing passwords.
+ *
+ * @param {Function} next - Callback to pass control to the next hook in the Mongoose lifecycle.
+ */
 UserSchema.pre("save", async function(next) {
   if (!this.isModified("password")) {
     return next();
@@ -38,12 +51,25 @@ UserSchema.pre("save", async function(next) {
 });
 
 UserSchema.methods = {
+  /**
+   * Compares an unencrypted password attempt against the user's hashed password.
+   *
+   * @param {string} password - The plain-text password to check.
+   * @returns {Promise<boolean>} Resolves to true if the given password securely matches the hash.
+   */
   compareHash(password) {
     return bcrypt.compare(password, this.password);
   }
 };
 
 UserSchema.statics = {
+  /**
+   * Generates a signed JSON Web Token using the system's auth secret.
+   *
+   * @param {Object} payload - Data payload to include inside the JWT.
+   * @param {string} payload.id - The unique user database ID.
+   * @returns {string} The resulting JWT token containing the payload and expiration config.
+   */
   generateToken({ id }) {
     return jwt.sign({ id }, authConfig.secret, {
       expiresIn: authConfig.ttl


### PR DESCRIPTION
## Assumptions
- The core focus for this PR is to provide detailed, onboarding-friendly JSDoc strings for `User.js`, `Product.js`, and `Order.js` in the `minicurso-setac` backend models folder.
- There are no runtime logic changes made, only inline documentation.
- The JSDoc block covers schema intentions, enums, relationships, and custom methods like `.pre("save")` or `generateToken()`.

## Alternatives Not Chosen
- Adding full TypeScript definitions (`d.ts` files). This was not chosen because it would expand the scope beyond adding JSDoc comments to existing files.

## How To Pivot
- To change the level of detail, you can adjust the JSDoc comments within the Mongoose Schema files (`User.js`, `Product.js`, `Order.js`). If documentation is required for the API routes and controllers, the PR scope would need to be expanded.

## Next Knobs
- **Files:** Additional documentation can be added to the controllers or middleware in `PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/`.
- **Formatting:** A linter/formatter script can be created to enforce JSDoc rules across the repo.

---
*PR created automatically by Jules for task [13846290583634872036](https://jules.google.com/task/13846290583634872036) started by @lucasew*