### PR TITLE
📝 Docs: Add JSDoc to minicurso backend controllers

### DIFF
--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/OrderController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/OrderController.js
@@ -1,7 +1,21 @@
 const { Order } = require("../models/Order");
 const { User } = require("../models/User");
 
+/**
+ * Controller handling operations for customer orders.
+ * Manages the lifecycle of an order from creation by an attendant
+ * to listing active orders, and finally updating them to completed status.
+ */
 class OrderController {
+  /**
+   * Creates a new order assigned to a specific table.
+   * Associates the order with the currently authenticated attendant making the request,
+   * registers the requested products, and returns the populated order details.
+   *
+   * @param {import("express").Request} req - The Express request object. `req.userId` must be populated by the AuthMiddleware, and the body must contain `products` and `table`.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the newly generated order with populated product details.
+   */
   async store(req, res) {
     // 1. Obtém os dados necessários para criar uma comanda
     const { products, table } = req.body;
@@ -19,6 +33,15 @@ class OrderController {
     return res.status(201).json(order);
   }
 
+  /**
+   * Fetches the current list of pending active orders.
+   * Filters orders by "IN PREPARATION" status to present a view for attendants or kitchen staff.
+   * Populates referenced products and the name of the attendant who submitted the order.
+   *
+   * @param {import("express").Request} req - The Express request object.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns an array of orders in preparation.
+   */
   async list(req, res) {
     const orders = await Order.find({ status: "IN PREPARATION" })
       .populate("products")
@@ -27,6 +50,15 @@ class OrderController {
     return res.json(orders);
   }
 
+  /**
+   * Completes an existing order.
+   * Finds an order by its ID from request params and updates its state to "DONE".
+   * Use this endpoint when an order is finalized and delivered to the table.
+   *
+   * @param {import("express").Request} req - The Express request object containing the `orderId` parameter.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the updated order object or a 404 error if not found.
+   */
   async update(req, res) {
     // 1. Obtém o ID da ordem do corpo da requisição
     const { orderId } = req.params;

--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/ProductController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/ProductController.js
@@ -1,6 +1,18 @@
 const { Product } = require("../models/Product");
 
+/**
+ * Controller responsible for managing products.
+ * Handles CRUD operations associated with menu items or inventory records.
+ */
 class ProductController {
+  /**
+   * Creates a new product entry in the database.
+   * Stores product details like name, description, price, and category type.
+   *
+   * @param {import("express").Request} req - The Express request object containing `name`, `description`, `price`, and `type` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the newly created product document.
+   */
   async store(req, res) {
     const { name, description, price, type } = req.body;
 
@@ -8,6 +20,14 @@ class ProductController {
 
     return res.status(201).json(product);
   }
+  /**
+   * Retrieves all available products from the database.
+   * Fetches the entire collection of products, typically used to display menu items or catalog data.
+   *
+   * @param {import("express").Request} req - The Express request object.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns an array of all registered products.
+   */
   async list(req, res) {
     const products = await Product.find();
 

--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/SessionController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/SessionController.js
@@ -1,6 +1,19 @@
 const { User } = require("../models/User");
 
+/**
+ * Controller responsible for authenticating users.
+ * Handles login flows and generates JWT tokens for authenticated sessions.
+ */
 class SessionController {
+  /**
+   * Authenticates a user based on their email and password.
+   * Validates the provided credentials and generates a signed JWT token
+   * if the login is successful, which can be used to authenticate subsequent requests.
+   *
+   * @param {import("express").Request} req - The Express request object containing `email` and `password` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the authenticated user object and a JWT token, or a 400 error for invalid credentials.
+   */
   async login(req, res) {
     const { email, password } = req.body;
 

--- a/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/UserController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/MINICURSO_/minicurso-setac/backend/src/app/controllers/UserController.js
@@ -1,6 +1,21 @@
 const { User } = require("../models/User");
 
+/**
+ * Controller responsible for managing user accounts.
+ * Handles the registration flow, including automatic permission assignment
+ * for the very first user created in the system.
+ */
 class UserController {
+  /**
+   * Registers a new user.
+   * Checks for email uniqueness to avoid duplicate accounts.
+   * If the database has no registered users yet, the new user will be granted
+   * "ADMIN" privileges automatically. Otherwise, defaults to "ATTENDANT".
+   *
+   * @param {import("express").Request} req - The Express request object containing `email`, `name`, and `password` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the created user object along with a newly generated JWT token, or a 400 error if the email is already in use.
+   */
   async store(req, res) {
     // 1. Obtem o e-mail do corpo da requisição POST
     const { email } = req.body;

--- a/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/OrderController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/OrderController.js
@@ -1,7 +1,21 @@
 const { Order } = require("../models/Order");
 const { User } = require("../models/User");
 
+/**
+ * Controller handling operations for customer orders.
+ * Manages the lifecycle of an order from creation by an attendant
+ * to listing active orders, and finally updating them to completed status.
+ */
 class OrderController {
+  /**
+   * Creates a new order assigned to a specific table.
+   * Associates the order with the currently authenticated attendant making the request,
+   * registers the requested products, and returns the populated order details.
+   *
+   * @param {import("express").Request} req - The Express request object. `req.userId` must be populated by the AuthMiddleware, and the body must contain `products` and `table`.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the newly generated order with populated product details.
+   */
   async store(req, res) {
     // 1. Obtém os dados necessários para criar uma comanda
     const { products, table } = req.body;
@@ -19,6 +33,15 @@ class OrderController {
     return res.status(201).json(order);
   }
 
+  /**
+   * Fetches the current list of pending active orders.
+   * Filters orders by "IN PREPARATION" status to present a view for attendants or kitchen staff.
+   * Populates referenced products and the name of the attendant who submitted the order.
+   *
+   * @param {import("express").Request} req - The Express request object.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns an array of orders in preparation.
+   */
   async list(req, res) {
     const orders = await Order.find({ status: "IN PREPARATION" })
       .populate("products")
@@ -27,6 +50,15 @@ class OrderController {
     return res.json(orders);
   }
 
+  /**
+   * Completes an existing order.
+   * Finds an order by its ID from request params and updates its state to "DONE".
+   * Use this endpoint when an order is finalized and delivered to the table.
+   *
+   * @param {import("express").Request} req - The Express request object containing the `orderId` parameter.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the updated order object or a 404 error if not found.
+   */
   async update(req, res) {
     // 1. Obtém o ID da ordem do corpo da requisição
     const { orderId } = req.params;

--- a/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/ProductController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/ProductController.js
@@ -1,6 +1,18 @@
 const { Product } = require("../models/Product");
 
+/**
+ * Controller responsible for managing products.
+ * Handles CRUD operations associated with menu items or inventory records.
+ */
 class ProductController {
+  /**
+   * Creates a new product entry in the database.
+   * Stores product details like name, description, price, and category type.
+   *
+   * @param {import("express").Request} req - The Express request object containing `name`, `description`, `price`, and `type` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the newly created product document.
+   */
   async store(req, res) {
     const { name, description, price, type } = req.body;
 
@@ -8,6 +20,14 @@ class ProductController {
 
     return res.status(201).json(product);
   }
+  /**
+   * Retrieves all available products from the database.
+   * Fetches the entire collection of products, typically used to display menu items or catalog data.
+   *
+   * @param {import("express").Request} req - The Express request object.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns an array of all registered products.
+   */
   async list(req, res) {
     const products = await Product.find();
 

--- a/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/SessionController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/SessionController.js
@@ -1,6 +1,19 @@
 const { User } = require("../models/User");
 
+/**
+ * Controller responsible for authenticating users.
+ * Handles login flows and generates JWT tokens for authenticated sessions.
+ */
 class SessionController {
+  /**
+   * Authenticates a user based on their email and password.
+   * Validates the provided credentials and generates a signed JWT token
+   * if the login is successful, which can be used to authenticate subsequent requests.
+   *
+   * @param {import("express").Request} req - The Express request object containing `email` and `password` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the authenticated user object and a JWT token, or a 400 error for invalid credentials.
+   */
   async login(req, res) {
     const { email, password } = req.body;
 

--- a/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/UserController.js
+++ b/PROJETOS/20221201-minicurso-galdino-setac/Minicurso/backend/src/app/controllers/UserController.js
@@ -1,6 +1,21 @@
 const { User } = require("../models/User");
 
+/**
+ * Controller responsible for managing user accounts.
+ * Handles the registration flow, including automatic permission assignment
+ * for the very first user created in the system.
+ */
 class UserController {
+  /**
+   * Registers a new user.
+   * Checks for email uniqueness to avoid duplicate accounts.
+   * If the database has no registered users yet, the new user will be granted
+   * "ADMIN" privileges automatically. Otherwise, defaults to "ATTENDANT".
+   *
+   * @param {import("express").Request} req - The Express request object containing `email`, `name`, and `password` in the body.
+   * @param {import("express").Response} res - The Express response object.
+   * @returns {Promise<import("express").Response>} Returns the created user object along with a newly generated JWT token, or a 400 error if the email is already in use.
+   */
   async store(req, res) {
     // 1. Obtem o e-mail do corpo da requisição POST
     const { email } = req.body;


### PR DESCRIPTION
**Assumptions:**
- I assumed the duplicated folders `MINICURSO_/minicurso-setac` and `Minicurso` are meant to be kept in sync, so I applied the documentation to both sets of controllers.
- Used JSDoc types (e.g. `@param {import("express").Request}`) to provide IDE autocomplete support in a plain JavaScript codebase.

**Alternatives Not Chosen:**
- Did not convert `.js` to TypeScript `.ts` as that would change executable code and build processes, violating the objective of documentation-only changes.
- Did not add line-by-line comments inside function bodies, strictly adhering to the "Essentialism" rule to avoid stating the obvious.

**How To Pivot:**
- If the documentation needs to be tailored differently for `MINICURSO_` and `Minicurso`, the reviewer can edit the comments in the respective files directly without affecting the application's runtime logic. The smallest concrete change would be modifying the JSDoc block in one specific controller.

**Next Knobs:**
- `UserController.js`: The documentation around 'ADMIN' and 'ATTENDANT' assignment can be updated if the business rules change.
- `OrderController.js`: The documented statuses ("IN PREPARATION", "DONE") can be expanded if new statuses are added.
- Additional documentation can be added to the `models` or `middlewares` folders following a similar format in future PRs.

---
*PR created automatically by Jules for task [15314128655014020315](https://jules.google.com/task/15314128655014020315) started by @lucasew*