### PR TITLE
🧹 Janitor: Fix empty catch blocks using centralized ErrorReporter

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-25: Never use empty catch blocks, report the error or print stack trace at least.

--- a/EXERCICIOS/cs_utfpr/sistemas-distribuidos/chat-rmi/nb/chat-rmi/src/main/java/biglucas/chat/server/Chat.java
+++ b/EXERCICIOS/cs_utfpr/sistemas-distribuidos/chat-rmi/nb/chat-rmi/src/main/java/biglucas/chat/server/Chat.java
@@ -7,6 +7,7 @@ package biglucas.chat.server;
 import biglucas.chat.rmi.IChatCallback;
 import biglucas.chat.rmi.exceptions.WhatsUTForbiddenActionException;
 import biglucas.chat.utils.OnMessage;
+import biglucas.utils.ErrorReporter;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -39,7 +40,7 @@ public class Chat {
         try {
         if (this.onMessage != null) this.onMessage.handleMessage(msg);
         System.out.printf("<%s> %s\n", from, message);
-        } catch (Exception e) {}
+        } catch (Exception e) { ErrorReporter.reportError(e); }
         
         
     }

--- a/EXERCICIOS/cs_utfpr/sistemas-distribuidos/chat-rmi/nb/chat-rmi/src/main/java/biglucas/utils/ErrorReporter.java
+++ b/EXERCICIOS/cs_utfpr/sistemas-distribuidos/chat-rmi/nb/chat-rmi/src/main/java/biglucas/utils/ErrorReporter.java
@@ -1,0 +1,9 @@
+package biglucas.utils;
+
+public class ErrorReporter {
+    public static void reportError(Throwable e) {
+        // Centralized error reporting
+        // E.g., send to Sentry if available.
+        e.printStackTrace();
+    }
+}

--- a/PROJETOS/20240717-java-poc-autoload/ErrorReporter.java
+++ b/PROJETOS/20240717-java-poc-autoload/ErrorReporter.java
@@ -1,0 +1,7 @@
+public class ErrorReporter {
+    public static void reportError(Throwable e) {
+        // Centralized error reporting
+        // E.g., send to Sentry if available.
+        e.printStackTrace();
+    }
+}

--- a/PROJETOS/20240717-java-poc-autoload/InternalClassLoader.java
+++ b/PROJETOS/20240717-java-poc-autoload/InternalClassLoader.java
@@ -16,7 +16,7 @@ public class InternalClassLoader extends URLClassLoader {
     super(name, new URL[0], parent);
     try {
       System.out.println(getScriptPath());
-    } catch (Exception e) {}
+    } catch (Exception e) { ErrorReporter.reportError(e); }
   }
 
   private boolean isJarsLoaded = false;


### PR DESCRIPTION
**What Changed**
- Added `.jules/janitor.md` with an entry stating never to use empty catch blocks.
- Added `ErrorReporter` to `biglucas.utils` in the `chat-rmi` project.
- Replaced the empty catch block in `Chat.java` with a call to `ErrorReporter.reportError(e)`.
- Added `ErrorReporter` to the default package in the `20240717-java-poc-autoload` project.
- Replaced the empty catch block in `InternalClassLoader.java` with a call to `ErrorReporter.reportError(e)`.

**Why This Helps**
- Enforces the project convention of having no silent failures and no empty catch blocks.
- Uses centralized error handling for these two projects instead of direct `e.printStackTrace()` scattered around the codebase.
- Avoids swallowing important exceptions silently.

**Before/After**
Before:
```java
        } catch (Exception e) {}
```
After:
```java
        } catch (Exception e) { ErrorReporter.reportError(e); }
```

**Verification**
- Ensured the `.java` files compile correctly using `javac`.
- Verified changes are staged correctly and do not include compiled `.class` files.

---

**Assumptions**
- The instruction to "create it in the project's shared utilities" means that for a monorepo playground, each independent project needs its own ErrorReporter to respect boundaries, since these are just standalone playground subprojects.
- Both projects are standard Java implementations requiring basic utility classes.

**Alternatives Not Chosen**
- Using `e.printStackTrace()` directly: Rejected because the global instructions explicitly state to create and use a centralized error-reporting function instead of local logging.
- Creating a global monorepo-level ErrorReporter: Rejected because configuring Java compilation and classpaths across dozens of standalone playground projects is brittle and breaks module boundaries.

**How To Pivot**
- If a global ErrorReporter is preferred for the entire monorepo, delete the local `ErrorReporter.java` files, create a new root-level module, and update the build commands/classpaths for all affected subprojects to point to the shared library.

**Next Knobs**
- Modify `ErrorReporter.reportError()` to integrate with Sentry or another logging backend.
- Run `find . -name "*.java" | xargs grep -E "e\.printStackTrace\(\)"` to identify and migrate other raw console error calls to the new ErrorReporter.

---
*PR created automatically by Jules for task [9336230595526914424](https://jules.google.com/task/9336230595526914424) started by @lucasew*